### PR TITLE
Changed sklearn in requirement.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy
 pandas
 matplotlib
-sklearn
+scikit-learn
 Flask==2.0.2
 Flask-RESTful==0.3.9
 tensorflow


### PR DESCRIPTION
The package name is scikit-learn but used using import sklearn
(pip install sklearn) instead of scikit-learn (pip install scikit-learn).